### PR TITLE
Dropping prefixes on predicate method is_leap? and fix spelling

### DIFF
--- a/exercises/leap/example.cr
+++ b/exercises/leap/example.cr
@@ -1,6 +1,6 @@
 class Year
-  def self.is_leap?(year : Int32)
-    Year.new(year).is_leap?
+  def self.leap?(year : Int32)
+    Year.new(year).leap?
   end
 
   :private
@@ -9,11 +9,11 @@ class Year
     @year = year
   end
 
-  def is_leap?
-    divisable_by?(400) || divisable_by?(4) && !divisable_by?(100)
+  def leap?
+    divisible_by?(400) || divisible_by?(4) && !divisible_by?(100)
   end
 
-  def divisable_by?(number : Int32)
+  def divisible_by?(number : Int32)
     @year % number == 0
   end
 end

--- a/exercises/leap/leap_spec.cr
+++ b/exercises/leap/leap_spec.cr
@@ -8,29 +8,29 @@ struct Time
 end
 
 describe "Leap" do
-  describe "" do
+  describe "#leap?" do
     it "marks 1996 as a leap year" do
-      Year.is_leap?(1996).should be_true
+      Year.leap?(1996).should be_true
     end
 
     pending "marks 1997 not as a leap year" do
-      Year.is_leap?(1997).should be_false
+      Year.leap?(1997).should be_false
     end
 
     pending "marks 1998 not as a leap year" do
-      Year.is_leap?(1998).should be_false
+      Year.leap?(1998).should be_false
     end
 
     pending "marks 1900 not as a leap year" do
-      Year.is_leap?(1900).should be_false
+      Year.leap?(1900).should be_false
     end
 
     pending "marks 2400 as a leap year" do
-      Year.is_leap?(2400).should be_true
+      Year.leap?(2400).should be_true
     end
 
     pending "marks 2000 as a leap year" do
-      Year.is_leap?(2000).should be_true
+      Year.leap?(2000).should be_true
     end
   end
 end


### PR DESCRIPTION
Per discussion in #12. I'll put in a separate PR for `Bob` to drop the `is_` prefixes as well.