### PR TITLE
Dropping prefixes on predicate methods in bob example solution

### DIFF
--- a/exercises/bob/example.cr
+++ b/exercises/bob/example.cr
@@ -1,11 +1,11 @@
 class Bob
   def self.hey(string : String)
     case
-    when self.is_silence?(string)
+    when self.silence?(string)
       "Fine. Be that way!"
-    when self.is_shouting?(string)
+    when self.shouting?(string)
       "Whoa, chill out!"
-    when self.is_question?(string)
+    when self.question?(string)
       "Sure."
     else
       "Whatever."
@@ -14,15 +14,15 @@ class Bob
 
   :private
 
-  def self.is_silence?(string : String)
+  def self.silence?(string : String)
     string.gsub(/\s+/, "").empty?
   end
 
-  def self.is_shouting?(string : String)
+  def self.shouting?(string : String)
     string == string.upcase && string =~ /[A-Z]/
   end
 
-  def self.is_question?(string : String)
+  def self.question?(string : String)
     string[string.size - 1] == '?'
   end
 end


### PR DESCRIPTION
Per discussion in #12. Didn't notice any more in the other exercises.