### PR TITLE
Correct failure messages in gigasecond exercise

### DIFF
--- a/exercises/gigasecond/gigasecond_spec.cr
+++ b/exercises/gigasecond/gigasecond_spec.cr
@@ -5,27 +5,27 @@ describe "Gigasecond" do
   describe "#from" do
     it "finds gigsecond from 2011_04_25" do
       result = Gigasecond.from(Time.new(2011, 4, 25, 0, 0, 0))
-      Time.new(2043, 1, 1, 1, 46, 40).should eq result
+      result.should eq Time.new(2043, 1, 1, 1, 46, 40)
     end
 
     pending "finds gigsecond from 1977_06_13" do
       result = Gigasecond.from(Time.new(1977, 6, 13, 0, 0, 0))
-      Time.new(2009, 2, 19, 1, 46, 40).should eq result
+      result.should eq Time.new(2009, 2, 19, 1, 46, 40)
     end
 
     pending "finds gigsecond from 1959_07_19" do
       result = Gigasecond.from(Time.new(1959, 7, 19, 0, 0, 0))
-      Time.new(1991, 3, 27, 1, 46, 40).should eq result
+      result.should eq Time.new(1991, 3, 27, 1, 46, 40)
     end
 
     pending "finds gigsecond with full_time specified" do
       result = Gigasecond.from(Time.new(2015, 1, 24, 22, 0, 0))
-      Time.new(2046, 10, 2, 23, 46, 40).should eq result
+      result.should eq Time.new(2046, 10, 2, 23, 46, 40)
     end
 
     pending "finds gigsecond with full_time with day rollover" do
       result = Gigasecond.from(Time.new(2015, 1, 24, 23, 59, 59))
-      Time.new(2046, 10, 3, 1, 46, 39).should eq result
+      result.should eq Time.new(2046, 10, 3, 1, 46, 39)
     end
 
     pending "test_with_your_birthday" do


### PR DESCRIPTION
The subjects in `gigasecond_spec.cr` were reversed which produces failure messages that have the expected value reversed with the "got" value.

Before:
```
  1) Gigasecond #from finds gigsecond from 2011_04_25
     Failure/Error: Time.new(2043, 1, 1, 1, 46, 40).should eq result

       expected: nil
            got: 2043-01-01 01:46:40
```

After:
```
  1) Gigasecond #from finds gigsecond from 2011_04_25
     Failure/Error: result.should eq Time.new(2043, 1, 1, 1, 46, 40)

       expected: 2043-01-01 01:46:40
            got: nil
```