### PR TITLE
largest-series-product: Expect exception if input invalid

### DIFF
--- a/exercises/largest-series-product/example.cr
+++ b/exercises/largest-series-product/example.cr
@@ -1,14 +1,13 @@
 class Series
+  @series : Array(Int64)
+
   def initialize(series : String)
-    if series =~ /\D/
-      @series = [] of Int64
-    else
-      @series = series.chars.map(&.to_i).map(&.to_i64)
-    end
+    raise ArgumentError.new("Series contains non-digit characters") if series =~ /\D/
+    @series = series.chars.map(&.to_i).map(&.to_i64)
   end
 
   def largest_product(span : Int32) : Int64
-    return -1i64 if span > @series.size || (@series.empty? && span > 0) || span < 0
+    raise ArgumentError.new("Invalid span") if span > @series.size || span < 0
     return 1i64 if span == 0
 
     product_from_sequence(create_sequences(span))

--- a/exercises/largest-series-product/largest_series_product_spec.cr
+++ b/exercises/largest-series-product/largest_series_product_spec.cr
@@ -37,7 +37,7 @@ describe "Series" do
       Series.new("99099").largest_product(3).should eq 0
     end
     it "rejects span longer than string length" do
-      Series.new("123").largest_product(4).should eq -1
+      expect_raises(ArgumentError) { Series.new("123").largest_product(4) }
     end
     it "reports 1 for empty string and empty product (0 span)" do
       Series.new("").largest_product(0).should eq 1
@@ -46,13 +46,13 @@ describe "Series" do
       Series.new("123").largest_product(0).should eq 1
     end
     it "rejects empty string and nonzero span" do
-      Series.new("").largest_product(1).should eq -1
+      expect_raises(ArgumentError) { Series.new("").largest_product(1) }
     end
     it "rejects invalid character in digits" do
-      Series.new("1234a5").largest_product(2).should eq -1
+      expect_raises(ArgumentError) { Series.new("1234a5").largest_product(2).should eq -1 }
     end
     it "rejects negative span" do
-      Series.new("12345").largest_product(-1).should eq -1
+      expect_raises(ArgumentError) { Series.new("12345").largest_product(-1) }
     end
   end
 end


### PR DESCRIPTION
The current tests expect -1 for invalid inputs, which seems odd; why
force callers to test for a sentinel value, when -1 can never be a
product of digits?

It is understood that x-common's JSON file has expectations of -1 as a
stand-in for the invalid values. However, it is also noted that the same
JSON file specifies that the expectation of -1 should be translated into
an appropriate expectation of failure in the target language.

In Crystal, it seems to be idiomatic to raise an exception for invalid
inputs. Thus, all tests that formerly expected -1 are changed to
`expect_raises(ArgumentError)`.

Note that there is precedent for expecting errors in Hamming where the
inputs are of unequal lengths: there too, the Crystal implementation of
this exercises expects that `ArgumentError` is raised.

The example implementation is updated to match this expectation.

Closes #38