### PR TITLE
Exercise generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ bin/configlet
 bin/configlet.exe
 CHECKLIST
 tmp/
+bin/generate

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,8 @@ test-assignment:
 
 test:
 	@for assignment in $(ASSIGNMENTS); do ASSIGNMENT=$$assignment $(MAKE) -s test-assignment || exit 1; done
+	@echo "running generator tests"
+	@cd $(GENERATORDIR) && crystal spec
 
 build_generator:
 	@crystal build $(GENERATORDIR)/generate.$(FILEEXT) -o bin/generate

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 ASSIGNMENT ?= ""
 IGNOREDIRS := "^(\.git|.crystal|docs|bin|img|script)$$"
 EXERCISESDIR ?= "exercises"
+GENERATORDIR ?= "src/generator"
 ASSIGNMENTS = $(shell find exercises -maxdepth 1 -mindepth 1 -type d | cut -d'/' -f2 | sort | grep -Ev $(IGNOREDIRS))
 
 FILEEXT := "cr"
@@ -23,3 +24,6 @@ test-assignment:
 
 test:
 	@for assignment in $(ASSIGNMENTS); do ASSIGNMENT=$$assignment $(MAKE) -s test-assignment || exit 1; done
+
+build_generator:
+	@crystal build $(GENERATORDIR)/generate.$(FILEEXT) -o bin/generate

--- a/config.json
+++ b/config.json
@@ -118,7 +118,8 @@
   "ignored": [
     "bin",
     "docs",
-    "img"
+    "img",
+    "src"
   ],
   "foregone": [
   ]

--- a/exercises/hello-world/spec/hello_world_spec.cr
+++ b/exercises/hello-world/spec/hello_world_spec.cr
@@ -2,17 +2,16 @@ require "spec"
 require "../src/*"
 
 describe "HelloWorld" do
-  describe "#hello" do
-    it "says hello with default 'World'" do
-      HelloWorld.hello.should eq "Hello, World!"
-    end
 
-    pending "says hello with one name" do
-      HelloWorld.hello("Max").should eq "Hello, Max!"
-    end
+  it "tests no name" do
+    HelloWorld.hello.should eq("Hello, World")
+  end
 
-    pending "says hello with another name" do
-      HelloWorld.hello("Alice").should eq "Hello, Alice!"
-    end
+  pending "tests sample name" do
+    HelloWorld.hello("Alice").should eq("Hello, Alice")
+  end
+
+  pending "tests other sample name" do
+    HelloWorld.hello("Bob").should eq("Hello, Bob")
   end
 end

--- a/exercises/hello-world/spec/hello_world_spec.cr
+++ b/exercises/hello-world/spec/hello_world_spec.cr
@@ -2,16 +2,15 @@ require "spec"
 require "../src/*"
 
 describe "HelloWorld" do
-
   it "tests no name" do
-    HelloWorld.hello.should eq("Hello, World")
+    HelloWorld.hello.should eq("Hello, World!")
   end
 
   pending "tests sample name" do
-    HelloWorld.hello("Alice").should eq("Hello, Alice")
+    HelloWorld.hello("Alice").should eq("Hello, Alice!")
   end
 
   pending "tests other sample name" do
-    HelloWorld.hello("Bob").should eq("Hello, Bob")
+    HelloWorld.hello("Bob").should eq("Hello, Bob!")
   end
 end

--- a/src/generator/exercises/exercise_generator.cr
+++ b/src/generator/exercises/exercise_generator.cr
@@ -1,0 +1,38 @@
+require "ecr"
+require "json"
+abstract class ExerciseGenerator
+  METADATA_REPOSITORY = "x-common"
+
+  def self.generate
+    new.generate
+  end
+
+  def generate
+    File.write(test_file, to_s)
+  end
+
+  def describe_name
+    exercise_name.split('-').map(&.capitalize).join
+  end
+
+  abstract def exercise_name
+  abstract def test_cases
+
+  private def root
+    File.expand_path(File.join("..", "..", "..", ".."), __FILE__)
+  end
+
+  private def test_file
+    File.expand_path(File.join("exercises", exercise_name, "spec", "#{exercise_name.tr("-","_")}_spec.cr"), root)
+  end
+
+  private def metadata_dir
+    File.expand_path(File.join("..", METADATA_REPOSITORY, "exercises", exercise_name), root)
+  end
+
+  private def data
+    File.read(File.join(metadata_dir, "canonical-data.json"))
+  end
+
+  ECR.def_to_s "#{__DIR__}/templates/example.tt"
+end

--- a/src/generator/exercises/exercise_generator.cr
+++ b/src/generator/exercises/exercise_generator.cr
@@ -1,5 +1,6 @@
 require "ecr"
 require "json"
+
 abstract class ExerciseGenerator
   METADATA_REPOSITORY = "x-common"
 
@@ -15,15 +16,15 @@ abstract class ExerciseGenerator
     exercise_name.split('-').map(&.capitalize).join
   end
 
-  abstract def exercise_name
-  abstract def test_cases
+  abstract def exercise_name : String
+  abstract def test_cases : Array(ExerciseTestCase)
 
   private def root
     File.expand_path(File.join("..", "..", "..", ".."), __FILE__)
   end
 
   private def test_file
-    File.expand_path(File.join("exercises", exercise_name, "spec", "#{exercise_name.tr("-","_")}_spec.cr"), root)
+    File.expand_path(File.join("exercises", exercise_name, "spec", "#{exercise_name.tr("-", "_")}_spec.cr"), root)
   end
 
   private def metadata_dir

--- a/src/generator/exercises/exercise_test_case.cr
+++ b/src/generator/exercises/exercise_test_case.cr
@@ -1,0 +1,8 @@
+abstract class ExerciseTestCase
+  abstract def workload
+  abstract def test_name
+
+  def pending?(index)
+    index == 0 ? "it" : "pending"
+  end
+end

--- a/src/generator/exercises/hello_world.cr
+++ b/src/generator/exercises/hello_world.cr
@@ -2,7 +2,6 @@ require "./exercise_generator"
 require "./exercise_test_case"
 
 class HelloWorldGenerator < ExerciseGenerator
-
   def exercise_name
     "hello-world"
   end
@@ -23,9 +22,9 @@ class HelloWorldTestCase < ExerciseTestCase
 
   def workload
     if !name
-      "HelloWorld.hello.should eq(\"Hello, World\")"
+      "HelloWorld.hello.should eq(\"#{expected}\")"
     else
-      "HelloWorld.hello(\"#{name}\").should eq(\"Hello, #{name}\")"
+      "HelloWorld.hello(\"#{name}\").should eq(\"#{expected}\")"
     end
   end
 

--- a/src/generator/exercises/hello_world.cr
+++ b/src/generator/exercises/hello_world.cr
@@ -1,0 +1,35 @@
+require "./exercise_generator"
+require "./exercise_test_case"
+
+class HelloWorldGenerator < ExerciseGenerator
+
+  def exercise_name
+    "hello-world"
+  end
+
+  def test_cases
+    JSON.parse(data)["cases"].map do |test_case|
+      HelloWorldTestCase.from_json(test_case.to_json)
+    end
+  end
+end
+
+class HelloWorldTestCase < ExerciseTestCase
+  JSON.mapping(
+    description: String,
+    name: String | Nil,
+    expected: String
+  )
+
+  def workload
+    if !name
+      "HelloWorld.hello.should eq(\"Hello, World\")"
+    else
+      "HelloWorld.hello(\"#{name}\").should eq(\"Hello, #{name}\")"
+    end
+  end
+
+  def test_name
+    description
+  end
+end

--- a/src/generator/exercises/hello_world.cr
+++ b/src/generator/exercises/hello_world.cr
@@ -21,10 +21,10 @@ class HelloWorldTestCase < ExerciseTestCase
   )
 
   def workload
-    if !name
-      "HelloWorld.hello.should eq(\"#{expected}\")"
-    else
+    if name
       "HelloWorld.hello(\"#{name}\").should eq(\"#{expected}\")"
+    else
+      "HelloWorld.hello.should eq(\"#{expected}\")"
     end
   end
 

--- a/src/generator/exercises/templates/example.tt
+++ b/src/generator/exercises/templates/example.tt
@@ -1,0 +1,10 @@
+require "spec"
+require "../src/*"
+
+describe <%= "#{describe_name.inspect} do" %>
+<% test_cases.each_with_index do |test_case, index| %>
+  <%= test_case.pending?(index) %> "tests <%= test_case.test_name %>" do
+    <%= test_case.workload %>
+  end
+<% end -%>
+end

--- a/src/generator/generate.cr
+++ b/src/generator/generate.cr
@@ -1,0 +1,15 @@
+require "./exercises/*"
+
+if ARGV.empty?
+  STDERR.puts "Exercise name required!\n"
+  exit
+end
+
+exercise = ARGV[0]
+
+klass = {{ExerciseGenerator.subclasses}}.find do |generator|
+  generator.to_s == "#{exercise.split('-').map(&.capitalize).join}Generator"
+end
+
+raise "Undefined Generator" unless klass
+klass.generate

--- a/src/generator/spec/exercise_generator_spec.cr
+++ b/src/generator/spec/exercise_generator_spec.cr
@@ -1,0 +1,27 @@
+require "spec"
+require "../exercises/exercise_generator"
+require "../exercises/exercise_test_case"
+
+class DummyGenerator < ExerciseGenerator
+  def exercise_name
+    "dummy"
+  end
+
+  def test_cases
+    [] of ExerciseTestCase
+  end
+end
+
+describe "ExerciseGenerator" do
+  describe "#describe_name" do
+    it "will return the name of the exercise in camel case" do
+      DummyGenerator.new.describe_name.should eq("Dummy")
+    end
+  end
+
+  describe "#to_s" do
+    it "will output the generator test file using the example.tt" do
+      DummyGenerator.new.to_s.should eq("require \"spec\"\nrequire \"../src/*\"\n\ndescribe \"Dummy\" do\nend\n")
+    end
+  end
+end

--- a/src/generator/spec/exercise_test_case_spec.cr
+++ b/src/generator/spec/exercise_test_case_spec.cr
@@ -1,0 +1,27 @@
+require "spec"
+require "json"
+require "../exercises/exercise_test_case"
+
+class DummyTestCase < ExerciseTestCase
+  JSON.mapping(
+    description: String
+  )
+
+  def workload; end
+
+  def test_name; end
+end
+
+describe "DummyTestCase" do
+  describe "#pending" do
+    it "outputs 'it' if the given integer is 0" do
+      dummy_test_case = DummyTestCase.from_json("{\"description\": \"hello\"}")
+      dummy_test_case.pending?(0).should eq("it")
+    end
+
+    it "outputs 'pending' if the given integer is greater than 0" do
+      dummy_test_case = DummyTestCase.from_json("{\"description\": \"hello\"}")
+      dummy_test_case.pending?(1).should eq("pending")
+    end
+  end
+end


### PR DESCRIPTION
### Overview
Based on https://github.com/exercism/xcrystal/issues/20
Creates an basic exercise generator for the Crystal language track.  The generator lives in the `src` directory.  This generator is based on the ruby generator - but is not a complete copy.  (Beware I am a Ruby dev, and have been getting into Crystal lately, so I have not completely learned all the Crystal best practices).  I have created a sample generator for the hello-world exercise as an example.

### Creating a new Generator
- Navigate to `src/generator/exercises` and create a new generator file (i.e. hello_world.cr).
- This file should contain 2 classes  
  - An exercise generator which must inherit from the ExerciseGenerator class
  - A test case class which inherits from ExerciseTestCase.
- The x-common repo must reside at the same level as the developer's crystal directory, and must contain a canonical-data.json file for the given exercise.

### Running the Generator
From within the xcrystal directory: 

`crystal src/generator/generate.cr hello-world`

Or build a binary
```
make build_generator
bin/generate hello-world
```
### Future Work/Issues
This is just an initial implementation and would like to keep this PR fairly focused on just getting a basic generator implemented. 

Currently a lot of the test suites write the tested method is a describe block (i.e. `describe "#hello"`).  I am not quite sure a clean way to implement this using the canonical data since it doesn't define the tested methods.

Let me know if you have any questions/concerns/comments!