### PR TITLE
Don't use json mapping for already parsed JSON

### DIFF
--- a/src/generator/exercises/hello_world.cr
+++ b/src/generator/exercises/hello_world.cr
@@ -8,17 +8,21 @@ class HelloWorldGenerator < ExerciseGenerator
 
   def test_cases
     JSON.parse(data)["cases"].map do |test_case|
-      HelloWorldTestCase.from_json(test_case.to_json)
+      HelloWorldTestCase.new(test_case)
     end
   end
 end
 
 class HelloWorldTestCase < ExerciseTestCase
-  JSON.mapping(
-    description: String,
-    name: String | Nil,
-    expected: String
-  )
+  private getter description : JSON::Any
+  private getter name : JSON::Any | Nil
+  private getter expected : JSON::Any
+
+  def initialize(test_case)
+    @description = test_case["description"]
+    @name = test_case["name"]?
+    @expected = test_case["expected"]
+  end
 
   def workload
     if name

--- a/src/generator/spec/exercise_test_case_spec.cr
+++ b/src/generator/spec/exercise_test_case_spec.cr
@@ -3,10 +3,6 @@ require "json"
 require "../exercises/exercise_test_case"
 
 class DummyTestCase < ExerciseTestCase
-  JSON.mapping(
-    description: String
-  )
-
   def workload; end
 
   def test_name; end
@@ -15,12 +11,12 @@ end
 describe "DummyTestCase" do
   describe "#pending" do
     it "outputs 'it' if the given integer is 0" do
-      dummy_test_case = DummyTestCase.from_json("{\"description\": \"hello\"}")
+      dummy_test_case = DummyTestCase.new
       dummy_test_case.pending?(0).should eq("it")
     end
 
     it "outputs 'pending' if the given integer is greater than 0" do
-      dummy_test_case = DummyTestCase.from_json("{\"description\": \"hello\"}")
+      dummy_test_case = DummyTestCase.new
       dummy_test_case.pending?(1).should eq("pending")
     end
   end


### PR DESCRIPTION
Removes parsing the test case JSON and then calling `to_json`.  
This PR changes that to just assign the wanted fields to instance vars.

Open to suggestions on a better way to do this!