### PR TITLE
Add forth

### DIFF
--- a/config.json
+++ b/config.json
@@ -118,6 +118,12 @@
       "difficulty": 1,
       "topics": [
       ]
+    },
+    {
+      "slug": "forth",
+      "difficulty": 3,
+      "topics": [
+      ]
     }
   ],
   "deprecated": [

--- a/exercises/forth/spec/forth_spec.cr
+++ b/exercises/forth/spec/forth_spec.cr
@@ -1,0 +1,198 @@
+require "spec"
+require "../src/*"
+
+describe "Forth" do
+  it "empty input results in empty stack" do
+    Forth.evaluate([] of String | Int32).should eq([] of String | Int32)
+  end
+
+  pending "numbers just get pushed onto the stack" do
+    Forth.evaluate(["1 2 3 4 5"]).should eq([1, 2, 3, 4, 5])
+  end
+
+  pending "all non-word characters are separators" do
+    Forth.evaluate(["1\u{0}2\u{13}3\n4\r5 6\t7"]).should eq([1, 2, 3, 4, 5, 6, 7])
+  end
+
+  pending "can add two numbers" do
+    Forth.evaluate(["1 2 +"]).should eq([3])
+  end
+
+  pending "errors if there is nothing on the stack" do
+    expect_raises do
+      Forth.evaluate(["+"])
+    end
+  end
+
+  pending "errors if there is only one value on the stack" do
+    expect_raises do
+      Forth.evaluate(["1 +"])
+    end
+  end
+
+  pending "can subtract two numbers" do
+    Forth.evaluate(["3 4 -"]).should eq([-1])
+  end
+
+  pending "errors if there is nothing on the stack" do
+    expect_raises do
+      Forth.evaluate(["-"])
+    end
+  end
+
+  pending "errors if there is only one value on the stack" do
+    expect_raises do
+      Forth.evaluate(["1 -"])
+    end
+  end
+
+  pending "can multiply two numbers" do
+    Forth.evaluate(["2 4 *"]).should eq([8])
+  end
+
+  pending "errors if there is nothing on the stack" do
+    expect_raises do
+      Forth.evaluate(["*"])
+    end
+  end
+
+  pending "errors if there is only one value on the stack" do
+    expect_raises do
+      Forth.evaluate(["1 *"])
+    end
+  end
+
+  pending "can divide two numbers" do
+    Forth.evaluate(["12 3 /"]).should eq([4])
+  end
+
+  pending "performs integer division" do
+    Forth.evaluate(["8 3 /"]).should eq([2])
+  end
+
+  pending "errors if dividing by zero" do
+    expect_raises do
+      Forth.evaluate(["4 0 /"])
+    end
+  end
+
+  pending "errors if there is nothing on the stack" do
+    expect_raises do
+      Forth.evaluate(["/"])
+    end
+  end
+
+  pending "errors if there is only one value on the stack" do
+    expect_raises do
+      Forth.evaluate(["1 /"])
+    end
+  end
+
+  pending "addition and subtraction" do
+    Forth.evaluate(["1 2 + 4 -"]).should eq([-1])
+  end
+
+  pending "multiplication and division" do
+    Forth.evaluate(["2 4 * 3 /"]).should eq([2])
+  end
+
+  pending "copies the top value on the stack" do
+    Forth.evaluate(["1 DUP"]).should eq([1, 1])
+  end
+
+  pending "is case-insensitive" do
+    Forth.evaluate(["1 2 Dup"]).should eq([1, 2, 2])
+  end
+
+  pending "errors if there is nothing on the stack" do
+    expect_raises do
+      Forth.evaluate(["dup"])
+    end
+  end
+
+  pending "removes the top value on the stack if it is the only one" do
+    Forth.evaluate(["1 drop"]).should eq([] of String | Int32)
+  end
+
+  pending "removes the top value on the stack if it is not the only one" do
+    Forth.evaluate(["1 2 drop"]).should eq([1])
+  end
+
+  pending "errors if there is nothing on the stack" do
+    expect_raises do
+      Forth.evaluate(["drop"])
+    end
+  end
+
+  pending "swaps the top two values on the stack if they are the only ones" do
+    Forth.evaluate(["1 2 swap"]).should eq([2, 1])
+  end
+
+  pending "swaps the top two values on the stack if they are not the only ones" do
+    Forth.evaluate(["1 2 3 swap"]).should eq([1, 3, 2])
+  end
+
+  pending "errors if there is nothing on the stack" do
+    expect_raises do
+      Forth.evaluate(["swap"])
+    end
+  end
+
+  pending "errors if there is only one value on the stack" do
+    expect_raises do
+      Forth.evaluate(["1 swap"])
+    end
+  end
+
+  pending "copies the second element if there are only two" do
+    Forth.evaluate(["1 2 over"]).should eq([1, 2, 1])
+  end
+
+  pending "copies the second element if there are more than two" do
+    Forth.evaluate(["1 2 3 over"]).should eq([1, 2, 3, 2])
+  end
+
+  pending "errors if there is nothing on the stack" do
+    expect_raises do
+      Forth.evaluate(["over"])
+    end
+  end
+
+  pending "errors if there is only one value on the stack" do
+    expect_raises do
+      Forth.evaluate(["1 over"])
+    end
+  end
+
+  pending "can consist of built-in words" do
+    Forth.evaluate([": dup-twice dup dup ;", "1 dup-twice"]).should eq([1, 1, 1])
+  end
+
+  pending "execute in the right order" do
+    Forth.evaluate([": countup 1 2 3 ;", "countup"]).should eq([1, 2, 3])
+  end
+
+  pending "can override other user-defined words" do
+    Forth.evaluate([": foo dup ;", ": foo dup dup ;", "1 foo"]).should eq([1, 1, 1])
+  end
+
+  pending "can override built-in words" do
+    Forth.evaluate([": swap dup ;", "1 swap"]).should eq([1, 1])
+  end
+
+  pending "can consist of arbitrary characters such as Unicode characters" do
+    Forth.evaluate([": € 220371 ; €"]).should eq([220371])
+  end
+
+  pending "cannot redefine numbers" do
+    expect_raises do
+      Forth.evaluate([": 1 2 ;"])
+    end
+  end
+
+  pending "errors if executing a non-existent word" do
+    expect_raises do
+      Forth.evaluate(["foo"])
+    end
+  end
+end

--- a/exercises/forth/spec/forth_spec.cr
+++ b/exercises/forth/spec/forth_spec.cr
@@ -3,196 +3,196 @@ require "../src/*"
 
 describe "Forth" do
   it "empty input results in empty stack" do
-    Forth.evaluate([] of String | Int32).should eq([] of String | Int32)
+    Forth.evaluate("").should eq([] of Int32)
   end
 
   pending "numbers just get pushed onto the stack" do
-    Forth.evaluate(["1 2 3 4 5"]).should eq([1, 2, 3, 4, 5])
+    Forth.evaluate("1 2 3 4 5").should eq([1, 2, 3, 4, 5])
   end
 
   pending "all non-word characters are separators" do
-    Forth.evaluate(["1\u{0}2\u{13}3\n4\r5 6\t7"]).should eq([1, 2, 3, 4, 5, 6, 7])
+    Forth.evaluate("1\u{0}2\u{13}3\n4\r5 6\t7").should eq([1, 2, 3, 4, 5, 6, 7])
   end
 
   pending "can add two numbers" do
-    Forth.evaluate(["1 2 +"]).should eq([3])
+    Forth.evaluate("1 2 +").should eq([3])
   end
 
   pending "errors if there is nothing on the stack" do
     expect_raises do
-      Forth.evaluate(["+"])
+      Forth.evaluate("+")
     end
   end
 
   pending "errors if there is only one value on the stack" do
     expect_raises do
-      Forth.evaluate(["1 +"])
+      Forth.evaluate("1 +")
     end
   end
 
   pending "can subtract two numbers" do
-    Forth.evaluate(["3 4 -"]).should eq([-1])
+    Forth.evaluate("3 4 -").should eq([-1])
   end
 
   pending "errors if there is nothing on the stack" do
     expect_raises do
-      Forth.evaluate(["-"])
+      Forth.evaluate("-")
     end
   end
 
   pending "errors if there is only one value on the stack" do
     expect_raises do
-      Forth.evaluate(["1 -"])
+      Forth.evaluate("1 -")
     end
   end
 
   pending "can multiply two numbers" do
-    Forth.evaluate(["2 4 *"]).should eq([8])
+    Forth.evaluate("2 4 *").should eq([8])
   end
 
   pending "errors if there is nothing on the stack" do
     expect_raises do
-      Forth.evaluate(["*"])
+      Forth.evaluate("*")
     end
   end
 
   pending "errors if there is only one value on the stack" do
     expect_raises do
-      Forth.evaluate(["1 *"])
+      Forth.evaluate("1 *")
     end
   end
 
   pending "can divide two numbers" do
-    Forth.evaluate(["12 3 /"]).should eq([4])
+    Forth.evaluate("12 3 /").should eq([4])
   end
 
   pending "performs integer division" do
-    Forth.evaluate(["8 3 /"]).should eq([2])
+    Forth.evaluate("8 3 /").should eq([2])
   end
 
   pending "errors if dividing by zero" do
     expect_raises do
-      Forth.evaluate(["4 0 /"])
+      Forth.evaluate("4 0 /")
     end
   end
 
   pending "errors if there is nothing on the stack" do
     expect_raises do
-      Forth.evaluate(["/"])
+      Forth.evaluate("/")
     end
   end
 
   pending "errors if there is only one value on the stack" do
     expect_raises do
-      Forth.evaluate(["1 /"])
+      Forth.evaluate("1 /")
     end
   end
 
   pending "addition and subtraction" do
-    Forth.evaluate(["1 2 + 4 -"]).should eq([-1])
+    Forth.evaluate("1 2 + 4 -").should eq([-1])
   end
 
   pending "multiplication and division" do
-    Forth.evaluate(["2 4 * 3 /"]).should eq([2])
+    Forth.evaluate("2 4 * 3 /").should eq([2])
   end
 
   pending "copies the top value on the stack" do
-    Forth.evaluate(["1 DUP"]).should eq([1, 1])
+    Forth.evaluate("1 DUP").should eq([1, 1])
   end
 
   pending "is case-insensitive" do
-    Forth.evaluate(["1 2 Dup"]).should eq([1, 2, 2])
+    Forth.evaluate("1 2 Dup").should eq([1, 2, 2])
   end
 
   pending "errors if there is nothing on the stack" do
     expect_raises do
-      Forth.evaluate(["dup"])
+      Forth.evaluate("dup")
     end
   end
 
   pending "removes the top value on the stack if it is the only one" do
-    Forth.evaluate(["1 drop"]).should eq([] of String | Int32)
+    Forth.evaluate("1 drop").should eq([] of Int32)
   end
 
   pending "removes the top value on the stack if it is not the only one" do
-    Forth.evaluate(["1 2 drop"]).should eq([1])
+    Forth.evaluate("1 2 drop").should eq([1])
   end
 
   pending "errors if there is nothing on the stack" do
     expect_raises do
-      Forth.evaluate(["drop"])
+      Forth.evaluate("drop")
     end
   end
 
   pending "swaps the top two values on the stack if they are the only ones" do
-    Forth.evaluate(["1 2 swap"]).should eq([2, 1])
+    Forth.evaluate("1 2 swap").should eq([2, 1])
   end
 
   pending "swaps the top two values on the stack if they are not the only ones" do
-    Forth.evaluate(["1 2 3 swap"]).should eq([1, 3, 2])
+    Forth.evaluate("1 2 3 swap").should eq([1, 3, 2])
   end
 
   pending "errors if there is nothing on the stack" do
     expect_raises do
-      Forth.evaluate(["swap"])
+      Forth.evaluate("swap")
     end
   end
 
   pending "errors if there is only one value on the stack" do
     expect_raises do
-      Forth.evaluate(["1 swap"])
+      Forth.evaluate("1 swap")
     end
   end
 
   pending "copies the second element if there are only two" do
-    Forth.evaluate(["1 2 over"]).should eq([1, 2, 1])
+    Forth.evaluate("1 2 over").should eq([1, 2, 1])
   end
 
   pending "copies the second element if there are more than two" do
-    Forth.evaluate(["1 2 3 over"]).should eq([1, 2, 3, 2])
+    Forth.evaluate("1 2 3 over").should eq([1, 2, 3, 2])
   end
 
   pending "errors if there is nothing on the stack" do
     expect_raises do
-      Forth.evaluate(["over"])
+      Forth.evaluate("over")
     end
   end
 
   pending "errors if there is only one value on the stack" do
     expect_raises do
-      Forth.evaluate(["1 over"])
+      Forth.evaluate("1 over")
     end
   end
 
   pending "can consist of built-in words" do
-    Forth.evaluate([": dup-twice dup dup ;", "1 dup-twice"]).should eq([1, 1, 1])
+    Forth.evaluate(": dup-twice dup dup ;1 dup-twice").should eq([1, 1, 1])
   end
 
   pending "execute in the right order" do
-    Forth.evaluate([": countup 1 2 3 ;", "countup"]).should eq([1, 2, 3])
+    Forth.evaluate(": countup 1 2 3 ;countup").should eq([1, 2, 3])
   end
 
   pending "can override other user-defined words" do
-    Forth.evaluate([": foo dup ;", ": foo dup dup ;", "1 foo"]).should eq([1, 1, 1])
+    Forth.evaluate(": foo dup ;: foo dup dup ;1 foo").should eq([1, 1, 1])
   end
 
   pending "can override built-in words" do
-    Forth.evaluate([": swap dup ;", "1 swap"]).should eq([1, 1])
+    Forth.evaluate(": swap dup ;1 swap").should eq([1, 1])
   end
 
   pending "can consist of arbitrary characters such as Unicode characters" do
-    Forth.evaluate([": € 220371 ; €"]).should eq([220371])
+    Forth.evaluate(": € 220371 ; €").should eq([220371])
   end
 
   pending "cannot redefine numbers" do
     expect_raises do
-      Forth.evaluate([": 1 2 ;"])
+      Forth.evaluate(": 1 2 ;")
     end
   end
 
   pending "errors if executing a non-existent word" do
     expect_raises do
-      Forth.evaluate(["foo"])
+      Forth.evaluate("foo")
     end
   end
 end

--- a/exercises/forth/src/example.cr
+++ b/exercises/forth/src/example.cr
@@ -1,0 +1,186 @@
+class Token
+  property type : Symbol
+  property string_value : String
+  property int_value : Int32
+
+  def initialize
+    @type = :EOF
+    @string_value = ""
+    @int_value = 0_i32
+  end
+
+  def eof?
+    type == :EOF
+  end
+end
+
+class Lexer
+  getter reader
+  getter token
+
+  def initialize(code : String)
+    @reader = Char::Reader.new(code)
+    @token = Token.new
+  end
+
+  def create_token
+    @token = Token.new unless @token.eof?
+  end
+
+  def next_token
+    create_token
+    skip_whitespace
+    case current_char
+    when '\0'
+      @token.type = :EOF
+    when ':'
+      next_char :":"
+    when ';'
+      next_char :";"
+    when .number?
+      consume_number
+    else
+      @token.type = :WORD
+      consume_string
+    end
+
+    @token
+  end
+
+  private def consume_string
+    start_pos = current_pos
+    while !current_char.number? && !current_char.whitespace? && !(current_char == '\0')
+      next_char
+    end
+    @token.string_value = reader.string.byte_slice(start_pos, current_pos - start_pos)
+  end
+
+  private def consume_number
+    integer = 0
+
+    while '0' <= current_char <= '9'
+      integer *= 10
+      integer += current_char - '0'
+      next_char
+    end
+
+    @token.type = :INT
+    @token.int_value = integer
+  end
+
+  private def current_char
+    reader.current_char
+  end
+
+  private def next_char
+    reader.next_char
+  end
+
+  private def next_char(token_type)
+    @token.type = token_type
+    next_char
+  end
+
+  private def current_pos
+    reader.pos
+  end
+
+  private def skip_whitespace
+    while current_char.whitespace? || current_char.control?
+      break unless reader.has_next?
+      next_char
+    end
+  end
+end
+
+class Forth
+  def self.evaluate(string)
+    new(string.join).evaluate
+  end
+
+  def initialize(code_string)
+    @lexer = Lexer.new(code_string)
+    @stack = Array(Int32).new
+    @defs = Hash(String, Array(Token)).new
+  end
+
+  def evaluate
+    loop do
+      evaluate_token(next_token)
+      return stack if token.eof?
+    end
+  end
+
+  private def evaluate_token(t)
+    case t.type
+    when :INT
+      parse_number(t)
+    when :WORD
+      parse_word(t)
+    when :":"
+      parse_def
+    when :EOF
+      return
+    else
+      raise "Unexpected Token!"
+    end
+  end
+
+  private def parse_number(t)
+    stack.push(t.int_value)
+  end
+
+  private def parse_word(t)
+    if defs[t.string_value.upcase]?
+      return defs[t.string_value.upcase].each { |t| evaluate_token(t) }
+    end
+
+    case t.string_value.upcase
+    when "+"
+      pop_twice { |a, b| stack.push(b + a) }
+    when "-"
+      pop_twice { |a, b| stack.push(b - a) }
+    when "*"
+      pop_twice { |a, b| stack.push(b * a) }
+    when "/"
+      pop_twice { |a, b| stack.push(b / a) }
+    when "DUP"
+      pop_once { |a| stack.push(a).push(a) }
+    when "DROP"
+      pop_once { }
+    when "SWAP"
+      pop_twice { |a, b| stack.push(a).push(b) }
+    when "OVER"
+      pop_twice { |a, b| stack.push(b).push(a).push(b) }
+    else
+      raise "Unknown word"
+    end
+  end
+
+  private def parse_def
+    next_token
+    raise "Invalid method name" if token.type == :INT
+    name = token.string_value.upcase
+    defs[name] = [] of Token
+    while next_token
+      raise "Invalid Definition" if token.type == :EOF
+      break if token.type == :";"
+      defs[name] << token
+    end
+  end
+
+  private def pop_once(&block)
+    raise "Invalid program" if stack.empty?
+    yield(stack.pop)
+  end
+
+  private def pop_twice(&block)
+    raise "Invalid program" if stack.size < 2
+    yield(stack.pop, stack.pop)
+  end
+
+  private property defs
+  private getter stack
+  private delegate token, to: @lexer
+  private delegate next_token, to: @lexer
+end

--- a/exercises/forth/src/example.cr
+++ b/exercises/forth/src/example.cr
@@ -38,6 +38,7 @@ class Lexer
     when ';'
       next_char :";"
     when .number?
+      @token.type = :INT
       consume_number
     else
       @token.type = :WORD
@@ -49,9 +50,11 @@ class Lexer
 
   private def consume_string
     start_pos = current_pos
-    while !current_char.number? && !current_char.whitespace? && !(current_char == '\0')
+
+    while valid_word_char?
       next_char
     end
+
     @token.string_value = reader.string.byte_slice(start_pos, current_pos - start_pos)
   end
 
@@ -60,20 +63,11 @@ class Lexer
 
     while '0' <= current_char <= '9'
       integer *= 10
-      integer += current_char - '0'
+      integer += current_char.to_i
       next_char
     end
 
-    @token.type = :INT
     @token.int_value = integer
-  end
-
-  private def current_char
-    reader.current_char
-  end
-
-  private def next_char
-    reader.next_char
   end
 
   private def next_char(token_type)
@@ -91,11 +85,18 @@ class Lexer
       next_char
     end
   end
+
+  private def valid_word_char?
+    !current_char.number? && !current_char.whitespace? && !(current_char == '\0')
+  end
+
+  private delegate current_char, to: @reader
+  private delegate next_char, to: @reader
 end
 
 class Forth
-  def self.evaluate(string)
-    new(string.join).evaluate
+  def self.evaluate(code_string)
+    new(code_string).evaluate
   end
 
   def initialize(code_string)

--- a/src/generator/exercises/forth.cr
+++ b/src/generator/exercises/forth.cr
@@ -1,0 +1,57 @@
+require "./exercise_generator"
+require "./exercise_test_case"
+
+class ForthGenerator < ExerciseGenerator
+  def exercise_name
+    "forth"
+  end
+
+  def test_cases
+    test_cases = [] of JSON::Any
+    JSON.parse(data).each do |k, v|
+      v.each do |a, b|
+        test_cases.concat(b) if a.as_s == "cases"
+      end
+    end
+    test_cases.map do |test_case|
+      ForthTestCase.new(test_case)
+    end
+  end
+end
+
+class ForthTestCase < ExerciseTestCase
+  private getter input : JSON::Any
+  private getter description : JSON::Any
+  private getter expected : JSON::Any
+
+  def initialize(test_case)
+    @input = fix_empty_array(test_case["input"])
+    @description = test_case["description"]
+    @expected = fix_empty_array(test_case["expected"])
+  end
+
+  def workload
+    if !(expected == nil)
+      "Forth.evaluate(#{input}).should eq(#{expected})"
+    else
+      <<-WL
+      expect_raises do
+            Forth.evaluate(#{input})
+          end
+      WL
+    end
+  end
+
+  def test_name
+    description
+  end
+
+  private def fix_empty_array(json)
+    if json.to_s.match(/\[\]/)
+      json = "[] of String | Int32".to_json
+      JSON.parse(json)
+    else
+      json
+    end
+  end
+end

--- a/src/generator/exercises/forth.cr
+++ b/src/generator/exercises/forth.cr
@@ -20,23 +20,23 @@ class ForthGenerator < ExerciseGenerator
 end
 
 class ForthTestCase < ExerciseTestCase
-  private getter input : JSON::Any
+  private getter input : JSON::Any | String
   private getter description : JSON::Any
   private getter expected : JSON::Any
 
   def initialize(test_case)
-    @input = fix_empty_array(test_case["input"])
+    @input = test_case["input"].as_a.join
     @description = test_case["description"]
     @expected = fix_empty_array(test_case["expected"])
   end
 
   def workload
     if !(expected == nil)
-      "Forth.evaluate(#{input}).should eq(#{expected})"
+      "Forth.evaluate(#{input.inspect}).should eq(#{expected})"
     else
       <<-WL
       expect_raises do
-            Forth.evaluate(#{input})
+            Forth.evaluate(#{input.inspect})
           end
       WL
     end
@@ -48,8 +48,7 @@ class ForthTestCase < ExerciseTestCase
 
   private def fix_empty_array(json)
     if json.to_s.match(/\[\]/)
-      json = "[] of String | Int32".to_json
-      JSON.parse(json)
+      JSON.parse("[] of Int32".to_json)
     else
       json
     end

--- a/src/generator/exercises/templates/example.tt
+++ b/src/generator/exercises/templates/example.tt
@@ -3,7 +3,7 @@ require "../src/*"
 
 describe <%= "#{describe_name.inspect} do" %>
 <% test_cases.each_with_index do |test_case, index| %>
-  <%= test_case.pending?(index) %> "tests <%= test_case.test_name %>" do
+  <%= test_case.pending?(index) %> "<%= test_case.test_name %>" do
     <%= test_case.workload %>
   end
 <% end -%>


### PR DESCRIPTION
Adds the forth exercise.

This was a tough (and fun!) one to implement (granted I wrote a Lexer), so I gave it a difficulty of 3 (although I'm not sure how that gets used).  I am open to suggestions on the example implementation.  I am not sure if the input should be an array or just a string, I am leaning towards a string since that is more natural for parsing a language.

```ruby (current)
Forth.evaluate(": DUP-TWICE DUP DUP ; 1 DUP-TWICE")
```
vs
```ruby
Forth.evaluate([": DUP-TWICE DUP DUP ;", "1 DUP-TWICE"])
```

I removed the hardcoding of "tests" in the template, I think that is best left up to the generator implementation. 

It was also a PITA to parse the json for this exercise, so that might be a bit messy.

I also had an issue which I noticed from https://github.com/exercism/xcrystal/pull/57 where I needed to fix empty arrays, so there might be some way to reduce that duplication going forward.
