### PR TITLE
Remove "tests" from template

### DIFF
--- a/exercises/acronym/spec/acronym_spec.cr
+++ b/exercises/acronym/spec/acronym_spec.cr
@@ -2,31 +2,31 @@ require "spec"
 require "../src/*"
 
 describe "Acronym" do
-  it "tests basic" do
+  it "does basic" do
     Acronym.abbreviate("Portable Network Graphics").should eq("PNG")
   end
 
-  it "tests lowercase words" do
+  pending "does lowercase words" do
     Acronym.abbreviate("Ruby on Rails").should eq("ROR")
   end
 
-  it "tests camelcase" do
+  pending "does camelcase" do
     Acronym.abbreviate("HyperText Markup Language").should eq("HTML")
   end
 
-  it "tests punctuation" do
+  pending "does punctuation" do
     Acronym.abbreviate("First In, First Out").should eq("FIFO")
   end
 
-  it "tests all caps words" do
+  pending "does all caps words" do
     Acronym.abbreviate("PHP: Hypertext Preprocessor").should eq("PHP")
   end
 
-  it "tests non-acronym all caps word" do
+  pending "does non-acronym all caps word" do
     Acronym.abbreviate("GNU Image Manipulation Program").should eq("GIMP")
   end
 
-  it "tests hyphenated" do
+  pending "does hyphenated" do
     Acronym.abbreviate("Complementary metal-oxide semiconductor").should eq("CMOS")
   end
 end

--- a/exercises/hello-world/spec/hello_world_spec.cr
+++ b/exercises/hello-world/spec/hello_world_spec.cr
@@ -2,15 +2,15 @@ require "spec"
 require "../src/*"
 
 describe "HelloWorld" do
-  it "tests no name" do
+  it "no name" do
     HelloWorld.hello.should eq("Hello, World!")
   end
 
-  pending "tests sample name" do
+  pending "sample name" do
     HelloWorld.hello("Alice").should eq("Hello, Alice!")
   end
 
-  pending "tests other sample name" do
+  pending "other sample name" do
     HelloWorld.hello("Bob").should eq("Hello, Bob!")
   end
 end

--- a/src/generator/exercises/acronym.cr
+++ b/src/generator/exercises/acronym.cr
@@ -29,6 +29,6 @@ class AcronymTestCase < ExerciseTestCase
   end
 
   def test_name
-    description
+    "does #{description}"
   end
 end

--- a/src/generator/exercises/templates/example.tt
+++ b/src/generator/exercises/templates/example.tt
@@ -3,7 +3,7 @@ require "../src/*"
 
 describe <%= "#{describe_name.inspect} do" %>
 <% test_cases.each_with_index do |test_case, index| %>
-  <%= test_case.pending?(index) %> "tests <%= test_case.test_name %>" do
+  <%= test_case.pending?(index) %> "<%= test_case.test_name %>" do
     <%= test_case.workload %>
   end
 <% end -%>


### PR DESCRIPTION
Removes hardcoding of the word 'tests' from the test template and regenerates hello-world and acronym