### PR TITLE
Remove problems array from config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,24 +4,6 @@
   "repository": "https://github.com/exercism/xcrystal",
   "active": true,
   "test_pattern": "_spec.cr",
-  "problems": [
-    "hello-world",
-    "hamming",
-    "gigasecond",
-    "rna-transcription",
-    "bob",
-    "raindrops",
-    "leap",
-    "pangram",
-    "largest-series-product",
-    "bracket-push",
-    "sieve",
-    "roman-numerals",
-    "atbash-cipher",
-    "anagram",
-    "react",
-    "acronym"
-  ],
   "exercises": [
     {
       "slug": "hello-world" ,


### PR DESCRIPTION
The problems array has been deprecated and we removed it on xruby https://github.com/exercism/xruby/pull/468. I think we are safe to remove it here as well.