### PR TITLE
Add blank solution file to diff-of-squares

### DIFF
--- a/exercises/difference-of-squares/src/difference_of_squares.cr
+++ b/exercises/difference-of-squares/src/difference_of_squares.cr
@@ -1,0 +1,1 @@
+# Please implement your solution to difference-of-squares in this file


### PR DESCRIPTION
Noticed this exercise was missing a blank solution file when pulling it from exercism cli